### PR TITLE
Add fallback parameter

### DIFF
--- a/.changeset/neat-flowers-fry.md
+++ b/.changeset/neat-flowers-fry.md
@@ -1,0 +1,5 @@
+---
+"@typed-storage/react": patch
+---
+
+Allow removing the value from localStorage

--- a/.changeset/shaggy-impalas-admire.md
+++ b/.changeset/shaggy-impalas-admire.md
@@ -1,0 +1,5 @@
+---
+"@typed-storage/react": minor
+---
+
+Add option to define fallback

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -63,6 +63,23 @@ export function MyComponent() {
 }
 ```
 
+### Fallback values
+
+You can define a fallback value for the key if it doesn't exist in the storage.
+
+```tsx
+export function MyComponent() {
+  const [theme, setTheme] = useStorage("theme", "light")
+
+  return (
+    <>
+      {/* This will be "light" because the key doesn't exist in the storage */}
+      <div>{theme}</div>
+    </>
+  )
+}
+```
+
 ## Installation
 
 You can install this package with any package manager you like.

--- a/packages/react/src/define-storage.test-d.ts
+++ b/packages/react/src/define-storage.test-d.ts
@@ -1,6 +1,6 @@
 import { z } from "zod"
 import { defineStorage } from "./define-storage.js"
-import { test, assertType } from "vitest"
+import { test, assertType, expectTypeOf } from "vitest"
 
 test("it's not possible to insert a value that violates the schema", () => {
   // ARRANGE
@@ -87,4 +87,41 @@ test("value must have type of undefined", () => {
 
   // ASSERT
   assertType<number | undefined>(result)
+})
+
+test("value is not undefined when setting a fallback value", () => {
+  // ARRANGE
+  const { useStorage } = defineStorage({
+    someNumberKey: z.number(),
+  })
+
+  // ACT
+  const [result] = useStorage("someNumberKey", 1)
+
+  // ASSERT
+  assertType<number>(result)
+})
+
+test("value can be undefined when fallback is set but the schema includes undefined", () => {
+  // ARRANGE
+  const { useStorage } = defineStorage({
+    someNumberKey: z.number().optional(),
+  })
+
+  // ACT
+  const [result] = useStorage("someNumberKey", 1)
+
+  // ASSERT
+  expectTypeOf(result).toEqualTypeOf<undefined | number>()
+})
+
+test("fallback value must have the conform to the schema", () => {
+  // ARRANGE
+  const { useStorage } = defineStorage({
+    someNumberKey: z.number(),
+  })
+
+  // ACT & ASSERT
+  // @ts-expect-error -- Cannot assign value that violates the schema
+  assertType(useStorage("someNumberKey", "not a number"))
 })

--- a/packages/react/src/define-storage.test.tsx
+++ b/packages/react/src/define-storage.test.tsx
@@ -47,6 +47,27 @@ test("reads existing value from the storage", () => {
   expect(result).toBe("someValue")
 })
 
+test("unset the value", () => {
+  // ARRANGE
+  const { useStorage } = defineStorage({
+    someKey: z.string(),
+  })
+
+  const subject = renderHook(() => useStorage("someKey"))
+  const [, setValue] = subject.result.current
+
+  // ACT
+
+  act(() => {
+    setValue(undefined)
+  })
+
+  const [result] = subject.result.current
+
+  // ASSERT
+  expect(result).toBeUndefined()
+})
+
 test("throws error when value violates schema", () => {
   // ARRANGE
   const { useStorage } = defineStorage({

--- a/packages/react/src/define-storage.test.tsx
+++ b/packages/react/src/define-storage.test.tsx
@@ -201,3 +201,68 @@ test("retrieve an object from local storage when mounting the component", () => 
   // ASSERT
   expect(result).toEqual({ someProperty: "someValue" })
 })
+
+test("returns the fallback value when the value for the key is not in the storage", () => {
+  // ARRANGE
+  const { useStorage } = defineStorage({
+    someKey: z.string(),
+  })
+
+  const subject = renderHook(() => useStorage("someKey", "fallbackValue"))
+
+  // ACT
+  const [result] = subject.result.current
+
+  // ASSERT
+  expect(result).toBe("fallbackValue")
+})
+
+test("throws an error when the fallback value violates the schema", () => {
+  // ARRANGE
+  const { useStorage } = defineStorage({
+    someKey: z.string(),
+  })
+
+  // ACT & ASSERT
+  expect(() => {
+    // @ts-expect-error -- number is not assignable to string
+    renderHook(() => useStorage("someKey", 1))
+  }).toThrowError()
+})
+
+test("returns the set value when a fallback value is defined but the key exists in the storage", () => {
+  // ARRANGE
+  const { useStorage } = defineStorage({
+    someKey: z.string(),
+  })
+
+  localStorage.setItem("someKey", "someValue")
+
+  const subject = renderHook(() => useStorage("someKey", "fallbackValue"))
+
+  // ACT
+  const [result] = subject.result.current
+
+  // ASSERT
+  expect(result).toBe("someValue")
+})
+
+test("unsetting the key returns the fallback value", () => {
+  // ARRANGE
+  const { useStorage } = defineStorage({
+    someKey: z.string(),
+  })
+
+  const subject = renderHook(() => useStorage("someKey", "fallbackValue"))
+  const [, setValue] = subject.result.current
+
+  // ACT
+  act(() => {
+    setValue(undefined)
+  })
+
+  const [result] = subject.result.current
+
+  // ASSERT
+  expect(result).toBe("fallbackValue")
+})

--- a/packages/react/src/define-storage.ts
+++ b/packages/react/src/define-storage.ts
@@ -23,12 +23,40 @@ export function standardValidate<T extends StandardSchemaV1>(
 export function defineStorage<T extends Record<string, StandardSchemaV1>>(
   schema: T,
 ) {
-  function useStorage(
-    key: KeyOf<T>,
+  function useStorage<K extends KeyOf<T>>(
+    key: K,
   ): [
-    StandardSchemaV1.InferOutput<T[KeyOf<T>]> | undefined,
-    (value: StandardSchemaV1.InferInput<T[KeyOf<T>]>) => void,
+    StandardSchemaV1.InferOutput<T[K]> | undefined,
+    (value: StandardSchemaV1.InferInput<T[K]> | undefined) => void,
+  ]
+  function useStorage<K extends KeyOf<T>>(
+    key: K,
+    fallbackValue: StandardSchemaV1.InferInput<T[K]>,
+  ): [
+    StandardSchemaV1.InferOutput<T[K]>,
+    (value: StandardSchemaV1.InferInput<T[K]> | undefined) => void,
+  ]
+  function useStorage<K extends KeyOf<T>>(
+    key: K,
+    fallbackValue?: unknown,
+  ): [
+    StandardSchemaV1.InferOutput<T[K]> | undefined,
+    (value: StandardSchemaV1.InferInput<T[K]> | undefined) => void,
   ] {
+    // Validate fallback value if provided
+    let validatedFallback: StandardSchemaV1.InferOutput<T[K]> | undefined =
+      undefined
+
+    if (fallbackValue !== undefined) {
+      // We know schema[key] exists because K extends KeyOf<T>
+      const schemaForKey = schema[key] as StandardSchemaV1
+      // This will throw if fallbackValue doesn't match the schema
+      validatedFallback = standardValidate(
+        schemaForKey,
+        fallbackValue as StandardSchemaV1.InferInput<T[K]>,
+      )
+    }
+
     const [value, setValue] = useState<
       StandardSchemaV1.InferOutput<T[KeyOf<T>]> | undefined
     >(() => {
@@ -54,8 +82,18 @@ export function defineStorage<T extends Record<string, StandardSchemaV1>>(
       )
     })
 
-    function set(newValue: StandardSchemaV1.InferInput<T[KeyOf<T>]>): void {
-      standardValidate(schema[key], newValue)
+    function set(
+      newValue: StandardSchemaV1.InferInput<T[K]> | undefined,
+    ): void {
+      if (newValue === undefined) {
+        localStorage.removeItem(key)
+        setValue(undefined)
+        return
+      }
+
+      // We know schema[key] exists because K extends KeyOf<T>
+      const schemaForKey = schema[key] as StandardSchemaV1
+      standardValidate(schemaForKey, newValue)
 
       if (typeof newValue === "string") {
         localStorage.setItem(key, newValue)

--- a/packages/react/src/define-storage.ts
+++ b/packages/react/src/define-storage.ts
@@ -58,10 +58,10 @@ export function defineStorage<T extends Record<string, StandardSchemaV1>>(
     }
 
     const [value, setValue] = useState<
-      StandardSchemaV1.InferOutput<T[KeyOf<T>]> | undefined
+      StandardSchemaV1.InferOutput<T[K]> | undefined
     >(() => {
       const storedValue = localStorage.getItem(key)
-      if (storedValue === null) return
+      if (storedValue === null) return validatedFallback
 
       let valueToValidate: unknown = storedValue
 
@@ -75,10 +75,12 @@ export function defineStorage<T extends Record<string, StandardSchemaV1>>(
         }
       }
 
+      // We know schema[key] exists because K extends KeyOf<T>
+      const schemaForKey = schema[key] as StandardSchemaV1
       return standardValidate(
-        schema[key],
+        schemaForKey,
         // We can assert here, because we know that the value we get is part of the schema
-        valueToValidate as StandardSchemaV1.InferInput<T[KeyOf<T>]>,
+        valueToValidate as StandardSchemaV1.InferInput<T[K]>,
       )
     })
 
@@ -87,7 +89,7 @@ export function defineStorage<T extends Record<string, StandardSchemaV1>>(
     ): void {
       if (newValue === undefined) {
         localStorage.removeItem(key)
-        setValue(undefined)
+        setValue(validatedFallback)
         return
       }
 


### PR DESCRIPTION
## What

Adding an optional parameter to define a fallback value.

Usage:

```tsx
const [value, setValue] = useStorage('theme', 'light');
```

In this example, because the a fallback value is set, the type of value goes from `string | undefined` to just `string`

## Why

Sometimes you want to define a fallback value, if the value is not defined in the local storage. 