### PR TITLE
fix(@typed-storage/react): Include typescript definitions

### DIFF
--- a/.changeset/young-groups-melt.md
+++ b/.changeset/young-groups-melt.md
@@ -1,0 +1,5 @@
+---
+"@typed-storage/react": patch
+---
+
+Include typescript definitions

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -4,6 +4,7 @@
   "license": "MIT",
   "type": "module",
   "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "scripts": {
     "build": "tsc",
     "dev": "vitest",


### PR DESCRIPTION
## What

This PR includes the missing type definitions to the project

## Why

Projects depend on the type definition files, so that the typescript compiler can understand the library's code.