### PR TITLE
feat(@typed-storage/react): allow using type-safe localStorage outside the React context

### DIFF
--- a/.changeset/poor-results-drop.md
+++ b/.changeset/poor-results-drop.md
@@ -1,0 +1,17 @@
+---
+"@typed-storage/react": minor
+---
+
+add light-weight wrapper around localStorage
+
+The `defineStorage` function now returns a `storage` property that allows you to call
+the localStorage API directly. You can use that when you want to access the localStorage
+outside of the React context.
+
+```ts
+const { storage } = defineStorage({
+  foo: z.string(),
+})
+
+storage.set("foo", "bar")
+```

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,9 @@ jobs:
       - name: Check formatting
         run: pnpm run format:check
 
+      - name: Build package
+        run: npx turbo run build
+
       - name: Lint files
         run: npx turbo run lint
 
@@ -43,9 +46,6 @@ jobs:
 
       - name: Run tests
         run: npx turbo run test
-
-      - name: Build package
-        run: npx turbo run build
 
       - name: Check exports
         run: npx turbo run test:exports

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -32,11 +32,11 @@ import { defineStorage } from "@typed-storage/react"
 // Feel free to use any other StandardSchema compatible library
 import { z } from "zod"
 
-const { useStorage } = defineStorage({
+const { useStorage, storage } = defineStorage({
   theme: z.enum(["light", "dark"]),
 })
 
-export { useStorage }
+export { useStorage, storage }
 ```
 
 2. Use the hook
@@ -78,6 +78,19 @@ export function MyComponent() {
     </>
   )
 }
+```
+
+## Outside of React
+
+To a type-safe way to access localStorage outside of React,
+you can use the `storage` property that is returned
+by the `defineStorage` function.
+
+```ts
+import { storage } from "./schema"
+
+storage.set("theme", "light")
+const theme = storage.get("theme")
 ```
 
 ## Installation

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -14,6 +14,7 @@
     "lint": "eslint ./src"
   },
   "dependencies": {
+    "@typed-storage/core": "workspace:*",
     "@standard-schema/spec": "^1.0.0"
   },
   "peerDependencies": {

--- a/packages/react/src/define-storage-hook.test-d.ts
+++ b/packages/react/src/define-storage-hook.test-d.ts
@@ -1,10 +1,10 @@
 import { z } from "zod"
-import { defineStorage } from "./define-storage.js"
+import { defineStorageHook } from "./define-storage-hook.js"
 import { test, assertType, expectTypeOf } from "vitest"
 
 test("it's not possible to insert a value that violates the schema", () => {
   // ARRANGE
-  const { useStorage } = defineStorage({
+  const { useStorage } = defineStorageHook({
     someKey: z.string(),
   })
 
@@ -17,7 +17,7 @@ test("it's not possible to insert a value that violates the schema", () => {
 
 test("it's not possible to access a non string key", () => {
   // ARRANGE
-  const { useStorage } = defineStorage({
+  const { useStorage } = defineStorageHook({
     someKey: z.string(),
   })
 
@@ -28,7 +28,7 @@ test("it's not possible to access a non string key", () => {
 
 test("it's not possible to access a non existent key", () => {
   // ARRANGE
-  const { useStorage } = defineStorage({
+  const { useStorage } = defineStorageHook({
     someKey: z.string(),
   })
 
@@ -39,7 +39,7 @@ test("it's not possible to access a non existent key", () => {
 
 test("the value has a type of string", () => {
   // ARRANGE
-  const { useStorage } = defineStorage({
+  const { useStorage } = defineStorageHook({
     someKey: z.string(),
   })
 
@@ -52,7 +52,7 @@ test("the value has a type of string", () => {
 
 test("the value has a type of boolean", () => {
   // ARRANGE
-  const { useStorage } = defineStorage({
+  const { useStorage } = defineStorageHook({
     someBooleanKey: z.boolean(),
   })
 
@@ -65,7 +65,7 @@ test("the value has a type of boolean", () => {
 
 test("the value has a type of number", () => {
   // ARRANGE
-  const { useStorage } = defineStorage({
+  const { useStorage } = defineStorageHook({
     someNumberKey: z.number(),
   })
 
@@ -78,7 +78,7 @@ test("the value has a type of number", () => {
 
 test("value must have type of undefined", () => {
   // ARRANGE
-  const { useStorage } = defineStorage({
+  const { useStorage } = defineStorageHook({
     someNumberKey: z.number(),
   })
 
@@ -91,7 +91,7 @@ test("value must have type of undefined", () => {
 
 test("value is not undefined when setting a fallback value", () => {
   // ARRANGE
-  const { useStorage } = defineStorage({
+  const { useStorage } = defineStorageHook({
     someNumberKey: z.number(),
   })
 
@@ -104,7 +104,7 @@ test("value is not undefined when setting a fallback value", () => {
 
 test("value can be undefined when fallback is set but the schema includes undefined", () => {
   // ARRANGE
-  const { useStorage } = defineStorage({
+  const { useStorage } = defineStorageHook({
     someNumberKey: z.number().optional(),
   })
 
@@ -117,7 +117,7 @@ test("value can be undefined when fallback is set but the schema includes undefi
 
 test("fallback value must have the conform to the schema", () => {
   // ARRANGE
-  const { useStorage } = defineStorage({
+  const { useStorage } = defineStorageHook({
     someNumberKey: z.number(),
   })
 

--- a/packages/react/src/define-storage-hook.test.tsx
+++ b/packages/react/src/define-storage-hook.test.tsx
@@ -1,7 +1,7 @@
 import { beforeEach, expect, test } from "vitest"
 import { renderHook } from "vitest-browser-react"
 import { act } from "react"
-import { defineStorage } from "./define-storage.js"
+import { defineStorageHook } from "./define-storage-hook.js"
 import { z } from "zod"
 
 beforeEach(() => {
@@ -10,7 +10,7 @@ beforeEach(() => {
 
 test("writes to the storage", () => {
   // ARRANGE
-  const { useStorage } = defineStorage({
+  const { useStorage } = defineStorageHook({
     someKey: z.string(),
   })
 
@@ -32,7 +32,7 @@ test("writes to the storage", () => {
 
 test("reads existing value from the storage", () => {
   // ARRANGE
-  const { useStorage } = defineStorage({
+  const { useStorage } = defineStorageHook({
     someKey: z.string(),
   })
 
@@ -49,7 +49,7 @@ test("reads existing value from the storage", () => {
 
 test("unset the value", () => {
   // ARRANGE
-  const { useStorage } = defineStorage({
+  const { useStorage } = defineStorageHook({
     someKey: z.string(),
   })
 
@@ -70,7 +70,7 @@ test("unset the value", () => {
 
 test("throws error when value violates schema", () => {
   // ARRANGE
-  const { useStorage } = defineStorage({
+  const { useStorage } = defineStorageHook({
     someKey: z.string().min(5),
   })
 
@@ -85,7 +85,7 @@ test("throws error when value violates schema", () => {
 
 test("throws an error when reading a value and it violates the schema", () => {
   // ARRANGE
-  const { useStorage } = defineStorage({
+  const { useStorage } = defineStorageHook({
     someKey: z.string().min(5),
   })
 
@@ -97,7 +97,7 @@ test("throws an error when reading a value and it violates the schema", () => {
 
 test("it returns undefined when there's not value for the key", () => {
   // ARRANGE
-  const { useStorage } = defineStorage({
+  const { useStorage } = defineStorageHook({
     someKey: z.string(),
   })
 
@@ -112,7 +112,7 @@ test("it returns undefined when there's not value for the key", () => {
 
 test("writes a number to the storage", () => {
   // ARRANGE
-  const { useStorage } = defineStorage({
+  const { useStorage } = defineStorageHook({
     someNumberKey: z.number(),
   })
 
@@ -134,7 +134,7 @@ test("writes a number to the storage", () => {
 
 test("writes a boolean to the storage", () => {
   // ARRANGE
-  const { useStorage } = defineStorage({
+  const { useStorage } = defineStorageHook({
     someBooleanKey: z.boolean(),
   })
 
@@ -156,7 +156,7 @@ test("writes a boolean to the storage", () => {
 
 test("writes an object to the storage", () => {
   // ARRANGE
-  const { useStorage } = defineStorage({
+  const { useStorage } = defineStorageHook({
     someObjectKey: z.object({
       someProperty: z.string(),
     }),
@@ -182,7 +182,7 @@ test("writes an object to the storage", () => {
 
 test("retrieve an object from local storage when mounting the component", () => {
   // ARRANGE
-  const { useStorage } = defineStorage({
+  const { useStorage } = defineStorageHook({
     someObjectKey: z.object({
       someProperty: z.string(),
     }),
@@ -204,7 +204,7 @@ test("retrieve an object from local storage when mounting the component", () => 
 
 test("returns the fallback value when the value for the key is not in the storage", () => {
   // ARRANGE
-  const { useStorage } = defineStorage({
+  const { useStorage } = defineStorageHook({
     someKey: z.string(),
   })
 
@@ -219,7 +219,7 @@ test("returns the fallback value when the value for the key is not in the storag
 
 test("throws an error when the fallback value violates the schema", () => {
   // ARRANGE
-  const { useStorage } = defineStorage({
+  const { useStorage } = defineStorageHook({
     someKey: z.string(),
   })
 
@@ -232,7 +232,7 @@ test("throws an error when the fallback value violates the schema", () => {
 
 test("returns the set value when a fallback value is defined but the key exists in the storage", () => {
   // ARRANGE
-  const { useStorage } = defineStorage({
+  const { useStorage } = defineStorageHook({
     someKey: z.string(),
   })
 
@@ -249,7 +249,7 @@ test("returns the set value when a fallback value is defined but the key exists 
 
 test("unsetting the key returns the fallback value", () => {
   // ARRANGE
-  const { useStorage } = defineStorage({
+  const { useStorage } = defineStorageHook({
     someKey: z.string(),
   })
 

--- a/packages/react/src/define-storage-hook.ts
+++ b/packages/react/src/define-storage-hook.ts
@@ -1,0 +1,115 @@
+import { type StandardSchemaV1 } from "@standard-schema/spec"
+import { useState } from "react"
+
+type KeyOf<T extends object> = Extract<keyof T, string>
+
+export function standardValidate<T extends StandardSchemaV1>(
+  schema: T,
+  input: StandardSchemaV1.InferInput<T>,
+): StandardSchemaV1.InferOutput<T> {
+  const result = schema["~standard"].validate(input)
+  if (result instanceof Promise) {
+    throw new TypeError("Schema validation must be synchronous")
+  }
+
+  // if the `issues` field exists, the validation failed
+  if (result.issues) {
+    throw new Error(JSON.stringify(result.issues, undefined, 2))
+  }
+
+  return result.value
+}
+
+export function defineStorageHook<T extends Record<string, StandardSchemaV1>>(
+  schema: T,
+) {
+  function useStorage<K extends KeyOf<T>>(
+    key: K,
+  ): [
+    StandardSchemaV1.InferOutput<T[K]> | undefined,
+    (value: StandardSchemaV1.InferInput<T[K]> | undefined) => void,
+  ]
+  function useStorage<K extends KeyOf<T>>(
+    key: K,
+    fallbackValue: StandardSchemaV1.InferInput<T[K]>,
+  ): [
+    StandardSchemaV1.InferOutput<T[K]>,
+    (value: StandardSchemaV1.InferInput<T[K]> | undefined) => void,
+  ]
+  function useStorage<K extends KeyOf<T>>(
+    key: K,
+    fallbackValue?: unknown,
+  ): [
+    StandardSchemaV1.InferOutput<T[K]> | undefined,
+    (value: StandardSchemaV1.InferInput<T[K]> | undefined) => void,
+  ] {
+    // Validate fallback value if provided
+    let validatedFallback: StandardSchemaV1.InferOutput<T[K]> | undefined =
+      undefined
+
+    if (fallbackValue !== undefined) {
+      // We know schema[key] exists because K extends KeyOf<T>
+      const schemaForKey = schema[key] as StandardSchemaV1
+      // This will throw if fallbackValue doesn't match the schema
+      validatedFallback = standardValidate(
+        schemaForKey,
+        fallbackValue as StandardSchemaV1.InferInput<T[K]>,
+      )
+    }
+
+    const [value, setValue] = useState<
+      StandardSchemaV1.InferOutput<T[K]> | undefined
+    >(() => {
+      const storedValue = localStorage.getItem(key)
+      if (storedValue === null) return validatedFallback
+
+      let valueToValidate: unknown = storedValue
+
+      try {
+        const parsed = JSON.parse(storedValue) as unknown
+        valueToValidate = parsed
+      } catch (error) {
+        const isJSONParseError = error instanceof SyntaxError
+        if (!isJSONParseError) {
+          throw error
+        }
+      }
+
+      // We know schema[key] exists because K extends KeyOf<T>
+      const schemaForKey = schema[key] as StandardSchemaV1
+      return standardValidate(
+        schemaForKey,
+        // We can assert here, because we know that the value we get is part of the schema
+        valueToValidate as StandardSchemaV1.InferInput<T[K]>,
+      )
+    })
+
+    function set(
+      newValue: StandardSchemaV1.InferInput<T[K]> | undefined,
+    ): void {
+      if (newValue === undefined) {
+        localStorage.removeItem(key)
+        setValue(validatedFallback)
+        return
+      }
+
+      // We know schema[key] exists because K extends KeyOf<T>
+      const schemaForKey = schema[key] as StandardSchemaV1
+      standardValidate(schemaForKey, newValue)
+
+      if (typeof newValue === "string") {
+        localStorage.setItem(key, newValue)
+      } else {
+        localStorage.setItem(key, JSON.stringify(newValue))
+      }
+
+      setValue(newValue)
+    }
+
+    return [value, set] as const
+  }
+
+  return {
+    useStorage,
+  }
+}

--- a/packages/react/src/define-storage.ts
+++ b/packages/react/src/define-storage.ts
@@ -1,115 +1,15 @@
-import { type StandardSchemaV1 } from "@standard-schema/spec"
-import { useState } from "react"
-
-type KeyOf<T extends object> = Extract<keyof T, string>
-
-export function standardValidate<T extends StandardSchemaV1>(
-  schema: T,
-  input: StandardSchemaV1.InferInput<T>,
-): StandardSchemaV1.InferOutput<T> {
-  const result = schema["~standard"].validate(input)
-  if (result instanceof Promise) {
-    throw new TypeError("Schema validation must be synchronous")
-  }
-
-  // if the `issues` field exists, the validation failed
-  if (result.issues) {
-    throw new Error(JSON.stringify(result.issues, undefined, 2))
-  }
-
-  return result.value
-}
+import type { StandardSchemaV1 } from "@standard-schema/spec"
+import { defineStorageHook } from "./define-storage-hook.js"
+import { defineStorage as defineCoreStorage } from "@typed-storage/core"
 
 export function defineStorage<T extends Record<string, StandardSchemaV1>>(
   schema: T,
 ) {
-  function useStorage<K extends KeyOf<T>>(
-    key: K,
-  ): [
-    StandardSchemaV1.InferOutput<T[K]> | undefined,
-    (value: StandardSchemaV1.InferInput<T[K]> | undefined) => void,
-  ]
-  function useStorage<K extends KeyOf<T>>(
-    key: K,
-    fallbackValue: StandardSchemaV1.InferInput<T[K]>,
-  ): [
-    StandardSchemaV1.InferOutput<T[K]>,
-    (value: StandardSchemaV1.InferInput<T[K]> | undefined) => void,
-  ]
-  function useStorage<K extends KeyOf<T>>(
-    key: K,
-    fallbackValue?: unknown,
-  ): [
-    StandardSchemaV1.InferOutput<T[K]> | undefined,
-    (value: StandardSchemaV1.InferInput<T[K]> | undefined) => void,
-  ] {
-    // Validate fallback value if provided
-    let validatedFallback: StandardSchemaV1.InferOutput<T[K]> | undefined =
-      undefined
-
-    if (fallbackValue !== undefined) {
-      // We know schema[key] exists because K extends KeyOf<T>
-      const schemaForKey = schema[key] as StandardSchemaV1
-      // This will throw if fallbackValue doesn't match the schema
-      validatedFallback = standardValidate(
-        schemaForKey,
-        fallbackValue as StandardSchemaV1.InferInput<T[K]>,
-      )
-    }
-
-    const [value, setValue] = useState<
-      StandardSchemaV1.InferOutput<T[K]> | undefined
-    >(() => {
-      const storedValue = localStorage.getItem(key)
-      if (storedValue === null) return validatedFallback
-
-      let valueToValidate: unknown = storedValue
-
-      try {
-        const parsed = JSON.parse(storedValue) as unknown
-        valueToValidate = parsed
-      } catch (error) {
-        const isJSONParseError = error instanceof SyntaxError
-        if (!isJSONParseError) {
-          throw error
-        }
-      }
-
-      // We know schema[key] exists because K extends KeyOf<T>
-      const schemaForKey = schema[key] as StandardSchemaV1
-      return standardValidate(
-        schemaForKey,
-        // We can assert here, because we know that the value we get is part of the schema
-        valueToValidate as StandardSchemaV1.InferInput<T[K]>,
-      )
-    })
-
-    function set(
-      newValue: StandardSchemaV1.InferInput<T[K]> | undefined,
-    ): void {
-      if (newValue === undefined) {
-        localStorage.removeItem(key)
-        setValue(validatedFallback)
-        return
-      }
-
-      // We know schema[key] exists because K extends KeyOf<T>
-      const schemaForKey = schema[key] as StandardSchemaV1
-      standardValidate(schemaForKey, newValue)
-
-      if (typeof newValue === "string") {
-        localStorage.setItem(key, newValue)
-      } else {
-        localStorage.setItem(key, JSON.stringify(newValue))
-      }
-
-      setValue(newValue)
-    }
-
-    return [value, set] as const
-  }
+  const { storage } = defineCoreStorage(schema)
+  const { useStorage } = defineStorageHook(schema)
 
   return {
+    storage,
     useStorage,
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -60,6 +60,9 @@ importers:
       '@standard-schema/spec':
         specifier: ^1.0.0
         version: 1.0.0
+      '@typed-storage/core':
+        specifier: workspace:*
+        version: link:../core
       '@types/react':
         specifier: ^19.1.1
         version: 19.1.1

--- a/turbo.json
+++ b/turbo.json
@@ -2,7 +2,8 @@
   "$schema": "https://turbo.build/schema.json",
   "tasks": {
     "build": {
-      "outputs": ["dist/**"]
+      "outputs": ["dist/**"],
+      "dependsOn": ["^build"]
     },
     "test": {},
     "test:exports": {},


### PR DESCRIPTION
## What?
This PR exports an additional light-wrapper around the localStorage api.

## Why?

There are cases where you need to access the localStorage outside the React context. We expose a very thin wrapper round the localStorage API, so that you get type-inference as well as schema validation.